### PR TITLE
RichEditBoxFormatter addition for ColorCode.UWP

### DIFF
--- a/ColorCode.Core/CodeColorizerBase.cs
+++ b/ColorCode.Core/CodeColorizerBase.cs
@@ -1,7 +1,6 @@
 ﻿using ColorCode.Compilation;
 using ColorCode.Parsing;
 using ColorCode.Styling;
-using System.Collections.Generic;
 
 namespace ColorCode
 {
@@ -19,13 +18,6 @@ namespace ColorCode
 
             this.Styles = Styles ?? StyleDictionary.DefaultLight;
         }
-
-        /// <summary>
-        /// Writes the parsed source code to the ouput using the specified style sheet.
-        /// </summary>
-        /// <param name="parsedSourceCode">The parsed source code to format and write to the output.</param>
-        /// <param name="scopes">The captured scopes for the parsed source code.</param>
-        protected abstract void Write(string parsedSourceCode, IList<Scope> scopes);
 
         /// <summary>
         /// The language parser that the <see cref="CodeColorizerBase"/> instance will use for its lifetime.

--- a/ColorCode.HTML/HtmlClassFormatter.cs
+++ b/ColorCode.HTML/HtmlClassFormatter.cs
@@ -85,7 +85,7 @@ namespace ColorCode
             return str.ToString();
         }
 
-        protected override void Write(string parsedSourceCode, IList<Scope> scopes)
+        protected void Write(string parsedSourceCode, IList<Scope> scopes)
         {
             var styleInsertions = new List<TextInsertion>();
 

--- a/ColorCode.HTML/HtmlFormatter.cs
+++ b/ColorCode.HTML/HtmlFormatter.cs
@@ -52,7 +52,7 @@ namespace ColorCode
             return buffer.ToString();
         }
 
-        protected override void Write(string parsedSourceCode, IList<Scope> scopes)
+        protected void Write(string parsedSourceCode, IList<Scope> scopes)
         {
             var styleInsertions = new List<TextInsertion>();
 

--- a/ColorCode.UWP/Common/ExtensionMethods.cs
+++ b/ColorCode.UWP/Common/ExtensionMethods.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Windows.UI;
 using Windows.UI.Xaml.Media;
 
 namespace ColorCode.UWP.Common
@@ -6,6 +7,13 @@ namespace ColorCode.UWP.Common
     public static class ExtensionMethods
     {
         public static SolidColorBrush GetSolidColorBrush(this string hex)
+        {
+            var color = GetColor(hex);
+            SolidColorBrush myBrush = new SolidColorBrush(color);
+            return myBrush;
+        }
+
+        public static Color GetColor(this string hex)
         {
             hex = hex.Replace("#", string.Empty);
 
@@ -23,8 +31,7 @@ namespace ColorCode.UWP.Common
             byte g = (byte)(Convert.ToUInt32(hex.Substring(index, 2), 16));
             index += 2;
             byte b = (byte)(Convert.ToUInt32(hex.Substring(index, 2), 16));
-            SolidColorBrush myBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(a, r, g, b));
-            return myBrush;
+            return Color.FromArgb(a, r, g, b);
         }
     }
 }

--- a/ColorCode.UWP/Common/VisualHelpers.cs
+++ b/ColorCode.UWP/Common/VisualHelpers.cs
@@ -1,0 +1,74 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+namespace ColorCode.Common
+{
+    public static class VisualHelpers
+    {
+        /// <summary>
+        /// Commandbars causing crashes at the mo
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="parent"></param>
+        /// <param name="deepscan"></param>
+        /// <param name="includeCommandBars"></param>
+        /// <returns></returns>
+        public static T FirstChildofType<T>(DependencyObject parent, bool deepscan = false, bool includeCommandBars = false)
+        {
+            if (parent == null) return (T)(object)null;
+            if (deepscan)
+            {
+                if (parent is ContentPresenter presenter)
+                {
+                    var _Child = presenter.Content as DependencyObject;
+                    if (_Child is T)
+                    {
+                        return (T)(object)_Child;
+                    }
+                    if (!(_Child is CommandBar) || includeCommandBars)
+                    {
+                        var next = (FirstChildofType<T>(_Child, deepscan));
+                        if (next is T)
+                        {
+                            return ((T)(object)next);
+                        }
+                    }
+                }
+                else if (parent is ContentControl control)
+                {
+                    var _Child = control.Content as DependencyObject;
+                    if (_Child is T)
+                    {
+                        return (T)(object)_Child;
+                    }
+                    if (!(_Child is CommandBar) || includeCommandBars)
+                    {
+                        var next = (FirstChildofType<T>(_Child, deepscan));
+                        if (next is T)
+                        {
+                            return ((T)(object)next);
+                        }
+                    }
+                }
+            }
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+            {
+                var _Child = VisualTreeHelper.GetChild(parent, i);
+                if (_Child is T)
+                {
+                    return ((T)(object)_Child);
+                }
+                if (!(_Child is CommandBar) || includeCommandBars)
+                {
+                    var next = (FirstChildofType<T>(_Child, deepscan));
+                    if (next is T)
+                    {
+                        return ((T)(object)next);
+                    }
+                }
+            }
+            return (T)(object)null;
+        }
+    }
+}

--- a/ColorCode.UWP/RichEditBoxFormatter.cs
+++ b/ColorCode.UWP/RichEditBoxFormatter.cs
@@ -1,0 +1,196 @@
+﻿using System.Collections.Generic;
+using ColorCode.Parsing;
+using Windows.UI.Xaml.Controls;
+using ColorCode.Styling;
+using Windows.UI.Text;
+using ColorCode.UWP.Common;
+using ColorCode.Common;
+using Windows.UI.Xaml;
+using System.Text.RegularExpressions;
+
+namespace ColorCode
+{
+    /// <summary>
+    /// Creates a <see cref="RichTextBlockFormatter"/>, for rendering Syntax Highlighted code to a RichTextBlock.
+    /// </summary>
+    public class RichEditBoxFormatter : CodeColorizerBase
+    {
+        /// <summary>
+        /// Creates a <see cref="RichTextBlockFormatter"/>, for rendering Syntax Highlighted code to a RichTextBlock.
+        /// </summary>
+        /// <param name="Theme">The Theme to use, determines whether to use Default Light or Default Dark.</param>
+        public RichEditBoxFormatter(ElementTheme Theme, ILanguageParser languageParser = null) : this(Theme == ElementTheme.Dark ? StyleDictionary.DefaultDark : StyleDictionary.DefaultLight, languageParser)
+        {
+        }
+
+        /// <summary>
+        /// Creates a <see cref="RichTextBlockFormatter"/>, for rendering Syntax Highlighted code to a RichTextBlock.
+        /// </summary>
+        /// <param name="Style">The Custom styles to Apply to the formatted Code.</param>
+        /// <param name="languageParser">The language parser that the <see cref="RichTextBlockFormatter"/> instance will use for its lifetime.</param>
+        public RichEditBoxFormatter(StyleDictionary Style = null, ILanguageParser languageParser = null) : base(Style, languageParser)
+        {
+        }
+
+        private RichEditBox RichEdit { get; set; }
+
+        public ILanguage Language
+        {
+            get => _Language;
+            set
+            {
+                _Language = value;
+                UpdateText();
+            }
+        }
+
+        private ILanguage _Language;
+
+        /// <summary>
+        /// Adds Syntax Highlighted Source Code to the provided RichTextBlock.
+        /// </summary>
+        /// <param name="sourceCode">The source code to colorize.</param>
+        /// <param name="language">The language to use to colorize the source code.</param>
+        /// <param name="RichEdit">The Control to add the Text to.</param>
+        public void AttachRichEditBox(RichEditBox RichEdit, ILanguage Language)
+        {
+            this.RichEdit = RichEdit;
+            RichEdit.TextChanging += RichEdit_TextChanging;
+            this.Language = Language;
+        }
+
+        private void RichEdit_TextChanging(RichEditBox sender, RichEditBoxTextChangingEventArgs args)
+        {
+            if (args.IsContentChanging)
+            {
+                UpdateText();
+            }
+        }
+
+        public void UpdateText()
+        {
+            if (RichEdit != null)
+            {
+                // Attempt to get Scrollviewer offsets, to preserve location.
+                var scroll = VisualHelpers.FirstChildofType<ScrollViewer>(RichEdit);
+                var vertOffset = scroll?.VerticalOffset;
+                var horOffset = scroll?.HorizontalOffset;
+
+                var selection = RichEdit.Document.Selection;
+                var selectionStart = selection.StartPosition;
+                var selectionEnd = selection.EndPosition;
+
+                RichEdit.Document.GetText(TextGetOptions.UseCrlf, out string raw);
+                RichEdit.Document.Undo();
+
+                RichEdit.Document.BeginUndoGroup();
+                RichEdit.Document.SetText(TextSetOptions.None, raw);
+
+                var newSelection = RichEdit.Document.Selection;
+                newSelection.StartPosition = selectionStart;
+                newSelection.EndPosition = selectionEnd;
+
+                Index = 0;
+                source = raw;
+
+                languageParser.Parse(raw, Language, (range, captures) => Style(range, captures));
+                RichEdit.Document.ApplyDisplayUpdates();
+                RichEdit.Document.EndUndoGroup();
+
+                if (scroll != null)
+                {
+                    scroll.ChangeView(horOffset, vertOffset, null, true);
+                }
+            }
+        }
+
+        private static int Index = 0;
+        private static string source = string.Empty;
+
+        protected void Style(string range, IList<Scope> scopes)
+        {
+            var scopeRange = source.Substring(Index);
+
+            var start = Index;
+
+            try
+            {
+                var previous = source.Remove(Index);
+                var crlfCorrection = CountOccurences(previous, "\r\n");
+                start -= crlfCorrection;
+            }
+            catch
+            {
+            }
+
+            var subIndex = scopeRange.IndexOf(range);
+            if (subIndex != -1)
+            {
+                start += subIndex;
+            }
+
+            foreach (var scope in scopes)
+            {
+                StyleFromScope(start, scope);
+            }
+
+            Index += range.Length;
+        }
+
+        private int CountOccurences(string str, string match)
+        {
+            return Regex.Matches(str, match).Count;
+        }
+
+        private void StyleFromScope(int Start, Scope Scope)
+        {
+            Start += Scope.Index;
+            var Range = RichEdit.Document.GetRange(Start, Start + Scope.Length);
+
+            string foreground = null;
+            string background = null;
+            bool italic = false;
+            bool bold = false;
+
+            if (Styles.Contains(Scope.Name))
+            {
+                Styling.Style style = Styles[Scope.Name];
+
+                foreground = style.Foreground;
+                background = style.Background;
+                italic = style.Italic;
+                bold = style.Bold;
+            }
+
+            if (!string.IsNullOrWhiteSpace(foreground))
+            {
+                Range.CharacterFormat.ForegroundColor = foreground.GetColor();
+            }
+
+            if (!string.IsNullOrWhiteSpace(background))
+            {
+                Range.CharacterFormat.BackgroundColor = background.GetColor();
+            }
+
+            if (italic)
+                Range.CharacterFormat.Italic = FormatEffect.On;
+
+            if (bold)
+                Range.CharacterFormat.Bold = FormatEffect.On;
+
+            foreach (var subScope in Scope.Children)
+            {
+                StyleFromScope(Start, subScope);
+            }
+        }
+
+        private void Reset(ITextRange Range)
+        {
+            var defaults = RichEdit.Document.GetDefaultCharacterFormat();
+            Range.CharacterFormat.Italic = FormatEffect.Off;
+            Range.CharacterFormat.Bold = FormatEffect.Off;
+            Range.CharacterFormat.BackgroundColor = defaults.BackgroundColor;
+            Range.CharacterFormat.ForegroundColor = defaults.ForegroundColor;
+        }
+    }
+}

--- a/ColorCode.UWP/RichTextBlockFormatter.cs
+++ b/ColorCode.UWP/RichTextBlockFormatter.cs
@@ -54,12 +54,12 @@ namespace ColorCode
         public void FormatInlines(string sourceCode, ILanguage Language, InlineCollection InlineCollection)
         {
             this.InlineCollection = InlineCollection;
-            languageParser.Parse(sourceCode, Language, (parsedSourceCode, captures) => Write(parsedSourceCode, captures));
+            languageParser.Parse(sourceCode, Language, (parsedSourceCode, captures) => Insert(parsedSourceCode, captures));
         }
 
         private InlineCollection InlineCollection { get; set; }
 
-        protected override void Write(string parsedSourceCode, IList<Scope> scopes)
+        protected void Insert(string parsedSourceCode, IList<Scope> scopes)
         {
             var styleInsertions = new List<TextInsertion>();
 

--- a/Tests/ColorCode.UWPTests/ColorCode.UWPTests.csproj
+++ b/Tests/ColorCode.UWPTests/ColorCode.UWPTests.csproj
@@ -97,6 +97,12 @@
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RichEditSample.xaml.cs">
+      <DependentUpon>RichEditSample.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="RichTextSample.xaml.cs">
+      <DependentUpon>RichTextSample.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">
@@ -122,6 +128,14 @@
     <Page Include="MainPage.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="RichEditSample.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="RichTextSample.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/ColorCode.UWPTests/MainPage.xaml
+++ b/Tests/ColorCode.UWPTests/MainPage.xaml
@@ -7,22 +7,20 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid x:Name="MainGrid" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition />
-        </Grid.RowDefinitions>
-        <ScrollViewer VerticalScrollMode="Disabled" HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto">
-            <StackPanel Orientation="Horizontal">
-                <Button Content="Render to Rich Text Block Light Theme" Click="RenderLight" Margin="5" />
-                <Button Content="Render to Rich Text Block Dark Theme" Click="RenderDark" Margin="5" />
-                <Button Content="Create HTML Light Theme" Click="HTMLLight"  Margin="5" />
-                <Button Content="Create HTML Dark Theme" Click="HTMLDark"  Margin="5" />
-            </StackPanel>
-        </ScrollViewer>
-
-        <ScrollViewer Grid.Row="1" IsHorizontalRailEnabled="True" HorizontalScrollMode="Auto" HorizontalScrollBarVisibility="Auto">
-            <RichTextBlock x:Name="PresentationBlock" FontFamily="Consolas" />
-        </ScrollViewer>
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
+            <Button x:Name="RichTextSample"
+                    Height="200"
+                    Width="200"
+                    Margin="5"
+                    Content="RichTextBlockFormatter"
+                    Click="RichTextSample_Click" />
+            <Button x:Name="RichEditSample"
+                    Height="200"
+                    Width="200"
+                    Margin="5"
+                    Content="RichEditBlockFormatter"
+                    Click="RichEditSample_Click" />
+        </StackPanel>
     </Grid>
 </Page>

--- a/Tests/ColorCode.UWPTests/RichEditSample.xaml
+++ b/Tests/ColorCode.UWPTests/RichEditSample.xaml
@@ -1,0 +1,17 @@
+﻿<Page
+    x:Class="ColorCode.UWPTests.RichEditSample"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid x:Name="MainGrid" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+        <ComboBox x:Name="LanguageBox" />
+        <RichEditBox x:Name="RichEdit" Grid.Row="1" IsTextPredictionEnabled="False" IsSpellCheckEnabled="False" />
+    </Grid>
+</Page>

--- a/Tests/ColorCode.UWPTests/RichEditSample.xaml.cs
+++ b/Tests/ColorCode.UWPTests/RichEditSample.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using Windows.UI.Xaml.Controls;
+
+namespace ColorCode.UWPTests
+{
+    public sealed partial class RichEditSample : Page
+    {
+        public RichEditSample()
+        {
+            this.InitializeComponent();
+            formatter = new RichEditBoxFormatter();
+
+            foreach (var language in Languages.All)
+            {
+                LanguageBox.Items.Add(language.Name);
+            }
+
+            var defaultLang = Languages.Markdown;
+            LanguageBox.SelectedItem = defaultLang.Name;
+            formatter.AttachRichEditBox(RichEdit, defaultLang);
+            LanguageBox.SelectionChanged += LanguageBox_SelectionChanged;
+        }
+
+        private void LanguageBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var language = Languages.All.FirstOrDefault(item => item.Name == LanguageBox.SelectedItem.ToString());
+            formatter.Language = language;
+        }
+
+        private readonly RichEditBoxFormatter formatter;
+    }
+}

--- a/Tests/ColorCode.UWPTests/RichTextSample.xaml
+++ b/Tests/ColorCode.UWPTests/RichTextSample.xaml
@@ -1,0 +1,28 @@
+﻿<Page
+    x:Class="ColorCode.UWPTests.RichTextSample"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:ColorCode.UWPTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid x:Name="MainGrid"  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+        <ScrollViewer VerticalScrollMode="Disabled" HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto">
+            <StackPanel Orientation="Horizontal">
+                <Button Content="Render to Rich Text Block Light Theme" Click="RenderLight" Margin="5" />
+                <Button Content="Render to Rich Text Block Dark Theme" Click="RenderDark" Margin="5" />
+                <Button Content="Create HTML Light Theme" Click="HTMLLight"  Margin="5" />
+                <Button Content="Create HTML Dark Theme" Click="HTMLDark"  Margin="5" />
+            </StackPanel>
+        </ScrollViewer>
+
+        <ScrollViewer Grid.Row="1" IsHorizontalRailEnabled="True" HorizontalScrollMode="Auto" HorizontalScrollBarVisibility="Auto">
+            <RichTextBlock x:Name="PresentationBlock" FontFamily="Consolas" />
+        </ScrollViewer>
+    </Grid>
+</Page>

--- a/Tests/ColorCode.UWPTests/RichTextSample.xaml.cs
+++ b/Tests/ColorCode.UWPTests/RichTextSample.xaml.cs
@@ -1,0 +1,96 @@
+﻿using ColorCode.Common;
+using ColorCode.Styling;
+using ColorCode.UWP.Common;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Windows.Storage;
+using Windows.Storage.Pickers;
+using Windows.System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace ColorCode.UWPTests
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class RichTextSample : Page
+    {
+        public RichTextSample()
+        {
+            this.InitializeComponent();
+        }
+
+        private async Task<Tuple<string, ILanguage>> GetCodeFileText()
+        {
+            var picker = new FileOpenPicker();
+            picker.FileTypeFilter.Add("*");
+
+            var file = await picker.PickSingleFileAsync();
+            if (file == null) return null;
+            string text = "";
+
+            using (var reader = new StreamReader(await file.OpenStreamForReadAsync(), true))
+            {
+                text = await reader.ReadToEndAsync();
+            }
+
+            ILanguage Language = Languages.FindById(file.FileType.Replace(".", "")) ?? Languages.CSharp;
+            return new Tuple<string, ILanguage>(text, Language);
+        }
+
+        private void RenderLight(object sender, RoutedEventArgs e)
+        {
+            MainGrid.RequestedTheme = ElementTheme.Light;
+            Render();
+        }
+
+        private void RenderDark(object sender, RoutedEventArgs e)
+        {
+            MainGrid.RequestedTheme = ElementTheme.Dark;
+            Render();
+        }
+
+        private async void Render()
+        {
+            PresentationBlock.Blocks.Clear();
+
+            var result = await GetCodeFileText();
+            if (result == null) return;
+
+            var formatter = new RichTextBlockFormatter(MainGrid.RequestedTheme);
+            var plainText = formatter.Styles[ScopeName.PlainText];
+            MainGrid.Background = (plainText?.Background ?? StyleDictionary.White).GetSolidColorBrush();
+            formatter.FormatRichTextBlock(result.Item1, result.Item2, PresentationBlock);
+        }
+
+        private void HTMLLight(object sender, RoutedEventArgs e)
+        {
+            MakeHTML(StyleDictionary.DefaultLight);
+        }
+
+        private void HTMLDark(object sender, RoutedEventArgs e)
+        {
+            MakeHTML(StyleDictionary.DefaultDark);
+        }
+
+        private async void MakeHTML(StyleDictionary Styles)
+        {
+            var result = await GetCodeFileText();
+            if (result == null) return;
+
+            var formatter = new HtmlFormatter(Styles);
+            var html = formatter.GetHtmlString(result.Item1, result.Item2);
+
+            var tempfile = await ApplicationData.Current.TemporaryFolder.CreateFileAsync("HTMLResult.html", CreationCollisionOption.ReplaceExisting);
+            await FileIO.WriteTextAsync(tempfile, html);
+
+            try
+            {
+                await Launcher.LaunchFileAsync(tempfile);
+            }
+            catch { }
+        }
+    }
+}


### PR DESCRIPTION
-Built most of the Formatter for RichEditBox.

-Removed Write abstract requirement on CodeColorizerBase.

-Modified Test/Sample app with navigation and RichEditBox sample.

A few issues with rendering remain that need to be fixed.