### PR TITLE
Added a default timeout for parsing

### DIFF
--- a/ColorCode.Core/CodeColorizerBase.cs
+++ b/ColorCode.Core/CodeColorizerBase.cs
@@ -1,6 +1,7 @@
 ﻿using ColorCode.Compilation;
 using ColorCode.Parsing;
 using ColorCode.Styling;
+using System;
 using System.Collections.Generic;
 
 namespace ColorCode
@@ -10,12 +11,13 @@ namespace ColorCode
     /// </summary>
     /// <param name="Style">The Custom styles to Apply to the formatted Code.</param>
     /// <param name="languageParser">The language parser that the <see cref="CodeColorizerBase"/> instance will use for its lifetime.</param>
+    /// <param name="defaultParseTimeoutSec">The default amount of time spent parsing before throwing a <see cref="System.Text.RegularExpressions.RegexMatchTimeoutException"/></param>
     public abstract class CodeColorizerBase
     {
-        public CodeColorizerBase(StyleDictionary Styles, ILanguageParser languageParser)
+        public CodeColorizerBase(StyleDictionary Styles, ILanguageParser languageParser, double defaultParseTimeoutSec = 4)
         {
             this.languageParser = languageParser
-                ?? new LanguageParser(new LanguageCompiler(Languages.CompiledLanguages), Languages.LanguageRepository);
+                ?? new LanguageParser(new LanguageCompiler(Languages.CompiledLanguages), Languages.LanguageRepository, defaultParseTimeoutSec);
 
             this.Styles = Styles ?? StyleDictionary.DefaultLight;
         }

--- a/ColorCode.Core/Compilation/ILanguageCompiler.cs
+++ b/ColorCode.Core/Compilation/ILanguageCompiler.cs
@@ -4,6 +4,6 @@ namespace ColorCode.Compilation
 {
     public interface ILanguageCompiler
     {
-        CompiledLanguage Compile(ILanguage language);
+        CompiledLanguage Compile(ILanguage language, double defaultParseTimeoutSec);
     }
 }

--- a/ColorCode.Core/Compilation/LanguageCompiler.cs
+++ b/ColorCode.Core/Compilation/LanguageCompiler.cs
@@ -12,6 +12,7 @@ namespace ColorCode.Compilation
     public class LanguageCompiler : ILanguageCompiler
     {
         private static readonly Regex numberOfCapturesRegex = new Regex(@"(?x)(?<!(\\|(?!\\)\(\?))\((?!\?)", RegexOptions.Compiled);
+        private static readonly TimeSpan defaultRegexParseTimeout = TimeSpan.FromSeconds(1);
         private readonly Dictionary<string, CompiledLanguage> compiledLanguages;
         private readonly ReaderWriterLockSlim compileLock;
 
@@ -103,7 +104,7 @@ namespace ColorCode.Compilation
             for (int i = 1; i < rules.Count; i++)
                 CompileRule(rules[i], regexBuilder, captures, false);
 
-            regex = new Regex(regexBuilder.ToString());
+            regex = new Regex(regexBuilder.ToString(), RegexOptions.None, defaultRegexParseTimeout);
         }
 
         private static void CompileRule(LanguageRule languageRule, StringBuilder regex, ICollection<string> captures, bool isFirstRule)

--- a/ColorCode.Core/Parsing/LanguageParser.cs
+++ b/ColorCode.Core/Parsing/LanguageParser.cs
@@ -12,14 +12,26 @@ namespace ColorCode.Parsing
     {
         private readonly ILanguageCompiler languageCompiler;
         private readonly ILanguageRepository languageRepository;
+        private readonly double defaultParseTimeoutSec = 1;
 
         public LanguageParser(ILanguageCompiler languageCompiler,
-                              ILanguageRepository languageRepository)
+                              ILanguageRepository languageRepository,
+                              double defaultParseTimeoutSec)
         {
             this.languageCompiler = languageCompiler;
             this.languageRepository = languageRepository;
+            this.defaultParseTimeoutSec = defaultParseTimeoutSec;
         }
 
+        /// <summary>
+        /// Formats the specified text using the rules defined by the specified language. 
+        /// </summary>
+        /// <param name="sourceCode">The text to parse</param>
+        /// <param name="language">The language used to define the syntax highlighting rules</param>
+        /// <param name="parseHandler">Called after parsing is complete</param>
+        /// <exception cref="System.Text.RegularExpressions.RegexMatchTimeoutException">
+        /// Thrown if parsing takes longer than the default specified duration
+        /// </exception>
         public void Parse(string sourceCode,
                           ILanguage language,
                           Action<string, IList<Scope>> parseHandler)
@@ -27,7 +39,7 @@ namespace ColorCode.Parsing
             if (string.IsNullOrEmpty(sourceCode))
                 return;
 
-            CompiledLanguage compiledLanguage = languageCompiler.Compile(language);
+            CompiledLanguage compiledLanguage = languageCompiler.Compile(language, defaultParseTimeoutSec);
 
             Parse(sourceCode, compiledLanguage, parseHandler);
         }
@@ -157,7 +169,7 @@ namespace ColorCode.Parsing
                 throw new InvalidOperationException("The nested language was not found in the language repository.");
             else
             {
-                CompiledLanguage nestedCompiledLanguage = languageCompiler.Compile(nestedLanguage);
+                CompiledLanguage nestedCompiledLanguage = languageCompiler.Compile(nestedLanguage, defaultParseTimeoutSec);
 
                 Match regexMatch = nestedCompiledLanguage.Regex.Match(regexCapture.Value, 0, regexCapture.Value.Length);
 


### PR DESCRIPTION
I've encountered an issue specifically with the CSS parsing regex where a line that doesn't end in a `}` and is quite a long will cause an extremely long parsing time (more than a few mins). 

To fix this issue, I've added a `defaultParseTimeoutSec` parameter to the `CodeColorizerBase` class that allows you to specify a default parse timeout. This allows a `RegexMatchTimeoutException` to be thrown when calling `LanguageParser.Parse`

Here's a minimal example of the issue:

[Dotnetfiddle version](https://dotnetfiddle.net/kgsnLb) (should take ~6 seconds to run, but adding more items will cause the time to go up very quickly)

Code:
``` csharp
using System;
using System.Text.RegularExpressions;
					
public class Program
{
	public static void Main()
	{
		Regex regex = new Regex(@"(?msi)(?:(\s*/\*.*?\*/)|(([a-z0-9#. \[\]=\"":_-]+)\s*(?:,\s*|{))+(?:(\s*/\*.*?\*/)|(?:\s*([a-z0-9 -]+\s*):\s*([a-z0-9#,<>\?%. \(\)\\\/\*\{\}:'\""!_=-]+);?))*\s*})");
		var regexMatch = regex.Match("   a, abbr, acronym, address, applet, article, aside, audio, b, big, blockquote, body, canvas, caption, center, cite, code {");
		Console.WriteLine(regexMatch.Captures.Count);
	}
}
```