### PR TITLE
Multi-target to .NET Standard 2.0.

### DIFF
--- a/ColorCode.Core/ColorCode.Core.csproj
+++ b/ColorCode.Core/ColorCode.Core.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard1.4</TargetFrameworks>
     <RootNamespace>ColorCode</RootNamespace>
     <AssemblyName>ColorCode.Core</AssemblyName>
     <Title>ColorCode-Universal</Title>

--- a/ColorCode.HTML/ColorCode.HTML.csproj
+++ b/ColorCode.HTML/ColorCode.HTML.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard1.4</TargetFrameworks>
     <RootNamespace>ColorCode</RootNamespace>
     <AssemblyName>ColorCode.HTML</AssemblyName>
     <Title>ColorCode.HTML</Title>


### PR DESCRIPTION
[It is recommended](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting) for packages that target .NET Standard 1.x to also target 2.0, to reduce dependencies.