### PR TITLE
Updated WinUI package to min 17763, update WinAppSdk to 1.1.4

### DIFF
--- a/ColorCode.WinUI/ColorCode.WinUI.csproj
+++ b/ColorCode.WinUI/ColorCode.WinUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.18362.0</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.17763.0</TargetFramework>
     <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <RootNamespace>ColorCode</RootNamespace>
     <AssemblyName>ColorCode.WinUI</AssemblyName>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -57,7 +57,7 @@
   <Choose>
     <When Condition="'$(IsWinUIProject)' == 'true'">
       <ItemGroup>
-        <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+        <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.4" />
       </ItemGroup>
     </When>
   </Choose>


### PR DESCRIPTION
This PR changes the TargetFramework for the WinUI package to `net5.0-windows10.0.17763.0`, the minimum LTS version supported by the WinAppSDK.

It also updates the `Microsoft.WindowsAppSDK` package to 1.1.4.
