### PR TITLE
Relicense to MIT

### DIFF
--- a/ColorCode.Core/CodeColorizerBase.cs
+++ b/ColorCode.Core/CodeColorizerBase.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using ColorCode.Compilation;
 using ColorCode.Parsing;

--- a/ColorCode.Core/Common/ExtensionMethods.cs
+++ b/ColorCode.Core/Common/ExtensionMethods.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/ColorCode.Core/Common/Guard.cs
+++ b/ColorCode.Core/Common/Guard.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/ColorCode.Core/Common/ILanguageRepository.cs
+++ b/ColorCode.Core/Common/ILanguageRepository.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/ColorCode.Core/Common/LanguageId.cs
+++ b/ColorCode.Core/Common/LanguageId.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace ColorCode.Common
 {

--- a/ColorCode.Core/Common/LanguageRepository.cs
+++ b/ColorCode.Core/Common/LanguageRepository.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/ColorCode.Core/Common/ScopeName.cs
+++ b/ColorCode.Core/Common/ScopeName.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace ColorCode.Common
 {

--- a/ColorCode.Core/Common/TextInsertion.cs
+++ b/ColorCode.Core/Common/TextInsertion.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using ColorCode.Parsing;
 

--- a/ColorCode.Core/Compilation/CompiledLanguage.cs
+++ b/ColorCode.Core/Compilation/CompiledLanguage.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Text.RegularExpressions;

--- a/ColorCode.Core/Compilation/ILanguageCompiler.cs
+++ b/ColorCode.Core/Compilation/ILanguageCompiler.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace ColorCode.Compilation
 {

--- a/ColorCode.Core/Compilation/LanguageCompiler.cs
+++ b/ColorCode.Core/Compilation/LanguageCompiler.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/ColorCode.Core/Compilation/Languages/Asax.cs
+++ b/ColorCode.Core/Compilation/Languages/Asax.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/Ashx.cs
+++ b/ColorCode.Core/Compilation/Languages/Ashx.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/Aspx.cs
+++ b/ColorCode.Core/Compilation/Languages/Aspx.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/AspxCs.cs
+++ b/ColorCode.Core/Compilation/Languages/AspxCs.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/AspxVb.cs
+++ b/ColorCode.Core/Compilation/Languages/AspxVb.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/CSharp.cs
+++ b/ColorCode.Core/Compilation/Languages/CSharp.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/Cpp.cs
+++ b/ColorCode.Core/Compilation/Languages/Cpp.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/Css.cs
+++ b/ColorCode.Core/Compilation/Languages/Css.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/FSharp.cs
+++ b/ColorCode.Core/Compilation/Languages/FSharp.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/Fortran.cs
+++ b/ColorCode.Core/Compilation/Languages/Fortran.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 // Copyright (c) 2015 Christopher Pardi.
 

--- a/ColorCode.Core/Compilation/Languages/Haskell.cs
+++ b/ColorCode.Core/Compilation/Languages/Haskell.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/Html.cs
+++ b/ColorCode.Core/Compilation/Languages/Html.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/Java.cs
+++ b/ColorCode.Core/Compilation/Languages/Java.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/JavaScript.cs
+++ b/ColorCode.Core/Compilation/Languages/JavaScript.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/Koka.cs
+++ b/ColorCode.Core/Compilation/Languages/Koka.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/Markdown.cs
+++ b/ColorCode.Core/Compilation/Languages/Markdown.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/Php.cs
+++ b/ColorCode.Core/Compilation/Languages/Php.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/PowerShell.cs
+++ b/ColorCode.Core/Compilation/Languages/PowerShell.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/Sql.cs
+++ b/ColorCode.Core/Compilation/Languages/Sql.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/Typescript.cs
+++ b/ColorCode.Core/Compilation/Languages/Typescript.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/VbDotNet.cs
+++ b/ColorCode.Core/Compilation/Languages/VbDotNet.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/Languages/Xml.cs
+++ b/ColorCode.Core/Compilation/Languages/Xml.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/RuleCaptures.cs
+++ b/ColorCode.Core/Compilation/RuleCaptures.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Compilation/RuleFormats.cs
+++ b/ColorCode.Core/Compilation/RuleFormats.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace ColorCode.Compilation
 {

--- a/ColorCode.Core/ILanguage.cs
+++ b/ColorCode.Core/ILanguage.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/ColorCode.Core/LanguageRule.cs
+++ b/ColorCode.Core/LanguageRule.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Common;

--- a/ColorCode.Core/Languages.cs
+++ b/ColorCode.Core/Languages.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.Threading;

--- a/ColorCode.Core/Parsing/ILanguageParser.cs
+++ b/ColorCode.Core/Parsing/ILanguageParser.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/ColorCode.Core/Parsing/LanguageParser.cs
+++ b/ColorCode.Core/Parsing/LanguageParser.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/ColorCode.Core/Parsing/Scope.cs
+++ b/ColorCode.Core/Parsing/Scope.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/ColorCode.Core/Styling/Style.cs
+++ b/ColorCode.Core/Styling/Style.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using ColorCode.Common;
 

--- a/ColorCode.Core/Styling/StyleDictionary.DefaultDark.cs
+++ b/ColorCode.Core/Styling/StyleDictionary.DefaultDark.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using ColorCode.Common;
 

--- a/ColorCode.Core/Styling/StyleDictionary.DefaultLight.cs
+++ b/ColorCode.Core/Styling/StyleDictionary.DefaultLight.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using ColorCode.Common;
 

--- a/ColorCode.Core/Styling/StyleDictionary.cs
+++ b/ColorCode.Core/Styling/StyleDictionary.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.ObjectModel;
 

--- a/ColorCode.HTML/Common/ExtensionMethods.cs
+++ b/ColorCode.HTML/Common/ExtensionMethods.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace ColorCode.HTML.Common
 {

--- a/ColorCode.HTML/HtmlClassFormatter.cs
+++ b/ColorCode.HTML/HtmlClassFormatter.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/ColorCode.HTML/HtmlFormatter.cs
+++ b/ColorCode.HTML/HtmlFormatter.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.IO;

--- a/ColorCode.UWP/Common/ExtensionMethods.cs
+++ b/ColorCode.UWP/Common/ExtensionMethods.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 #if WINUI

--- a/ColorCode.UWP/RichTextBlockFormatter.cs
+++ b/ColorCode.UWP/RichTextBlockFormatter.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using ColorCode.Parsing;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,11 +2,16 @@
 
   <PropertyGroup>
     <!-- Package Config -->
-    <Authors>Microsoft, William Bradley</Authors>
+    <Company>Microsoft</Company>
+    <Authors>Microsoft</Authors>
+    <Product>ColorCode Universal</Product>
+    <CommonTags>dotnet;Community;Toolkit;syntax;highlight</CommonTags>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <PackageProjectUrl>https://github.com/WilliamABradley/ColorCode-Universal</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/WilliamABradley/ColorCode-Universal/blob/master/LICENSE</PackageLicenseUrl>
-    <Copyright>Copyright © Microsoft Corporation, William Bradley 2017</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <Copyright>(c) .NET Foundation and Contributors. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/CommunityToolkit/ColorCode-Universal</PackageProjectUrl>
+    
     <!-- Project States -->
     <IsUwpProject>$(MSBuildProjectName.Contains('UWP'))</IsUwpProject>
     <IsWinUIProject>$(MSBuildProjectName.Contains('WinUI'))</IsWinUIProject>

--- a/Tests/ColorCode.BasicTests/Program.cs
+++ b/Tests/ColorCode.BasicTests/Program.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/Tests/ColorCode.UWPTests/App.xaml.cs
+++ b/Tests/ColorCode.UWPTests/App.xaml.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Windows.ApplicationModel;

--- a/Tests/ColorCode.UWPTests/MainPage.xaml.cs
+++ b/Tests/ColorCode.UWPTests/MainPage.xaml.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using ColorCode.Common;
 using ColorCode.Styling;

--- a/Tests/ColorCode.UWPTests/Properties/AssemblyInfo.cs
+++ b/Tests/ColorCode.UWPTests/Properties/AssemblyInfo.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Reflection;
 using System.Runtime.InteropServices;

--- a/Tests/ColorCode.WinUITests/App.xaml.cs
+++ b/Tests/ColorCode.WinUITests/App.xaml.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using Windows.ApplicationModel;

--- a/Tests/ColorCode.WinUITests/MainWindow.xaml.cs
+++ b/Tests/ColorCode.WinUITests/MainWindow.xaml.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using ColorCode.Common;
 using ColorCode.Styling;

--- a/build/UpdateHeaders.bat
+++ b/build/UpdateHeaders.bat
@@ -1,3 +1,3 @@
 @ECHO OFF
-PowerShell.exe -file "%~dp0build.ps1" -target=UpdateHeaders
+PowerShell.exe -file "%~dp0build.ps1" -Target UpdateHeaders
 PAUSE

--- a/build/header.txt
+++ b/build/header.txt
@@ -1,1 +1,3 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.

--- a/license.md
+++ b/license.md
@@ -1,31 +1,13 @@
-# Microsoft Public License (Ms-PL)
+# Community Toolkit
 
-This license governs use of the accompanying software. If you use the software, you accept this license. If you do not accept the license, do not use the software.
+Copyright © .NET Foundation and Contributors
 
-1. Definitions
+All rights reserved.
 
-    The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under U.S. copyright law.
+## MIT License (MIT)
 
-    A "contribution" is the original software, or any additions or changes to the software.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-    A "contributor" is any person that distributes its contribution under this license.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-    "Licensed patents" are a contributor's patent claims that read directly on its contribution.
-
-2. Grant of Rights
-
-    (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
-
-    (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
-
-3. Conditions and Limitations
-
-    (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
-
-    (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.
-
-    (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
-
-    (D) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
-
-    (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/readme.md
+++ b/readme.md
@@ -69,3 +69,7 @@ Please use [GitHub issues](https://github.com/WilliamABradley/ColorCode-Universa
 
 ## Contributing
 Want to help out and add some more parsing support, or add a new Formatter platform? Submit a PR!
+
+## License
+
+MIT


### PR DESCRIPTION
Resolves #20

After getting buy-in from past contributors and vetting the code history, as discussed in #20, we're relicensing the project to MIT to better align with the other licenses of projects within the Community Toolkit organization.