### PR TITLE
Update the regex for the PowerShell parser

### DIFF
--- a/ColorCode.Core/Common/ScopeName.cs
+++ b/ColorCode.Core/Common/ScopeName.cs
@@ -22,7 +22,7 @@ namespace ColorCode.Common
         public const string Keyword = "Keyword";
         public const string LanguagePrefix = "&";
         public const string PlainText = "Plain Text";
-        public const string PowerShellAttribute = "PowerShell PowerShellAttribute";
+        public const string PowerShellAttribute = "PowerShell Attribute";
         public const string PowerShellOperator = "PowerShell Operator";
         public const string PowerShellType = "PowerShell Type";
         public const string PowerShellVariable = "PowerShell Variable";

--- a/ColorCode.Core/Common/ScopeName.cs
+++ b/ColorCode.Core/Common/ScopeName.cs
@@ -26,6 +26,8 @@ namespace ColorCode.Common
         public const string PowerShellOperator = "PowerShell Operator";
         public const string PowerShellType = "PowerShell Type";
         public const string PowerShellVariable = "PowerShell Variable";
+        public const string PowerShellCommand = "PowerShell Command";
+        public const string PowerShellParameter = "PowerShell Parameter";
         public const string PreprocessorKeyword = "Preprocessor Keyword";
         public const string SqlSystemFunction = "SQL System Function";
         public const string String = "String";

--- a/ColorCode.Core/Compilation/Languages/PowerShell.cs
+++ b/ColorCode.Core/Compilation/Languages/PowerShell.cs
@@ -78,7 +78,7 @@ namespace ColorCode.Compilation.Languages
                                            {0, ScopeName.PowerShellVariable}
                                        }),
                                new LanguageRule(
-                                   @"\b(begin|break|catch|continue|data|do|dynamicparam|elseif|else|end|exit|filter|finally|foreach|for|from|function|if|in|param|process|return|switch|throw|trap|try|until|while)\b",
+                                   @"(?i)\b(begin|break|catch|continue|data|do|dynamicparam|elseif|else|end|exit|filter|finally|foreach|for|from|function|if|in|param|process|return|switch|throw|trap|try|until|while)\b",
                                    new Dictionary<int, string>
                                        {
                                            {1, ScopeName.Keyword}
@@ -125,7 +125,7 @@ namespace ColorCode.Compilation.Languages
                                        }
                                    ),
                                new LanguageRule(
-                                   @"(?s)\[(cmdletbinding|alias|outputtype|parameter|validatenotnull|validatenotnullorempty|validatecount|validateset|allownull|allowemptycollection|allowemptystring|validatescript|validaterange|validatepattern|validatelength|supportswildcards)[^\]]+\]",
+                                   @"(?is)\[(cmdletbinding|alias|outputtype|parameter|validatenotnull|validatenotnullorempty|validatecount|validateset|allownull|allowemptycollection|allowemptystring|validatescript|validaterange|validatepattern|validatelength|supportswildcards)[^\]]+\]",
                                    new Dictionary<int, string>
                                        {
                                            {1, ScopeName.PowerShellAttribute}

--- a/ColorCode.Core/Compilation/Languages/PowerShell.cs
+++ b/ColorCode.Core/Compilation/Languages/PowerShell.cs
@@ -84,6 +84,12 @@ namespace ColorCode.Compilation.Languages
                                            {1, ScopeName.Keyword}
                                        }),
                                new LanguageRule(
+                                   @"\b(\w+\-\w+)\b",
+                                   new Dictionary<int, string>
+                                       {
+                                           {1, ScopeName.PowerShellCommand}
+                                       }),
+                               new LanguageRule(
                                    @"-(?:c|i)?(?:eq|ne|gt|ge|lt|le|notlike|like|notmatch|match|notcontains|contains|replace)",
                                    new Dictionary<int, string>
                                        {
@@ -98,7 +104,14 @@ namespace ColorCode.Compilation.Languages
                                        }
                                    ),
                                new LanguageRule(
-                                   @"(?:\+=|-=|\*=|/=|%=|=|\+\+|--|\+|-|\*|/|%)",
+                                   @"-\w+\d*\w*",
+                                   new Dictionary<int, string>
+                                       {
+                                           {0, ScopeName.PowerShellParameter}
+                                       }
+                                   ),
+                               new LanguageRule(
+                                   @"(?:\+=|-=|\*=|/=|%=|=|\+\+|--|\+|-|\*|/|%|\||,)",
                                    new Dictionary<int, string>
                                        {
                                            {0, ScopeName.PowerShellOperator}
@@ -112,7 +125,7 @@ namespace ColorCode.Compilation.Languages
                                        }
                                    ),
                                new LanguageRule(
-                                   @"(?s)\[(CmdletBinding)[^\]]+\]",
+                                   @"(?s)\[(cmdletbinding|alias|outputtype|parameter|validatenotnull|validatenotnullorempty|validatecount|validateset|allownull|allowemptycollection|allowemptystring|validatescript|validaterange|validatepattern|validatelength|supportswildcards)[^\]]+\]",
                                    new Dictionary<int, string>
                                        {
                                            {1, ScopeName.PowerShellAttribute}
@@ -136,6 +149,7 @@ namespace ColorCode.Compilation.Languages
             {
                 case "posh":
                 case "ps1":
+                case "pwsh":
                     return true;
 
                 default:

--- a/ColorCode.Core/Styling/StyleDictionary.DefaultDark.cs
+++ b/ColorCode.Core/Styling/StyleDictionary.DefaultDark.cs
@@ -21,7 +21,7 @@ namespace ColorCode.Styling
         private const string VSDarkXMLComment = "#FF608B4E";
 
         private const string VSDarkComment = "#FF57A64A";
-        private const string VSDarkKeyword = "#FF";
+        private const string VSDarkKeyword = "#FF569CD6";
         private const string VSDarkGray = "#FF9B9B9B";
         private const string VSDarkNumber = "#FFB5CEA8";
         private const string VSDarkClass = "#FF4EC9B0";

--- a/ColorCode.Core/Styling/StyleDictionary.DefaultDark.cs
+++ b/ColorCode.Core/Styling/StyleDictionary.DefaultDark.cs
@@ -21,7 +21,7 @@ namespace ColorCode.Styling
         private const string VSDarkXMLComment = "#FF608B4E";
 
         private const string VSDarkComment = "#FF57A64A";
-        private const string VSDarkKeyword = "#FF569CD6";
+        private const string VSDarkKeyword = "#FF";
         private const string VSDarkGray = "#FF9B9B9B";
         private const string VSDarkNumber = "#FFB5CEA8";
         private const string VSDarkClass = "#FF4EC9B0";
@@ -196,6 +196,16 @@ namespace ColorCode.Styling
                     {
                         Foreground = OrangeRed,
                         ReferenceName = "powershellVariable"
+                    },
+                    new Style(ScopeName.PowerShellCommand)
+                    {
+                        Foreground = Yellow,
+                        ReferenceName = "powershellCommand"
+                    },
+                    new Style(ScopeName.PowerShellParameter)
+                    {
+                        Foreground = VSDarkGray,
+                        ReferenceName = "powershellParameter"
                     },
 
                     new Style(ScopeName.Type)

--- a/ColorCode.Core/Styling/StyleDictionary.DefaultLight.cs
+++ b/ColorCode.Core/Styling/StyleDictionary.DefaultLight.cs
@@ -181,6 +181,16 @@ namespace ColorCode.Styling
                         Foreground = OrangeRed,
                         ReferenceName = "powershellVariable"
                     },
+                    new Style(ScopeName.PowerShellCommand)
+                    {
+                        Foreground = Navy,
+                        ReferenceName = "powershellCommand"
+                    },
+                    new Style(ScopeName.PowerShellParameter)
+                    {
+                        Foreground = Gray,
+                        ReferenceName = "powershellParameter"
+                    },
 
                     new Style(ScopeName.Type)
                     {


### PR DESCRIPTION
Update the regex for the PowerShell parser:
1. Support matching the PowerShell cmdlets and parameters;
2. For operators, update the regex to match pipeline operator `|` and the array literal operator `,`;
3. For attributes, update the regex to match more available attributes;
4. Make attribute and keyword matching case insensitive;
5. Add `pwsh` as an alias for the `PowerShell` language;
6. Add the color setting for PowerShell command and parameter for both the default dark and light themes.