### PR TITLE
Add the regex language parser for JSON

### DIFF
--- a/ColorCode.Core/Common/LanguageId.cs
+++ b/ColorCode.Core/Common/LanguageId.cs
@@ -18,6 +18,7 @@ namespace ColorCode.Common
         public const string Html = "html";
         public const string Java = "java";
         public const string JavaScript = "javascript";
+        public const string Json = "json";
         public const string TypeScript = "typescript";
         public const string Php = "php";
         public const string PowerShell = "powershell";

--- a/ColorCode.Core/Common/ScopeName.cs
+++ b/ColorCode.Core/Common/ScopeName.cs
@@ -19,6 +19,10 @@ namespace ColorCode.Common
         public const string HtmlOperator = "HTML Operator";
         public const string HtmlServerSideScript = "HTML Server-Side Script";
         public const string HtmlTagDelimiter = "Html Tag Delimiter";
+        public const string JsonKey = "Json Key";
+        public const string JsonString = "Json String";
+        public const string JsonNumber = "Json Number";
+        public const string JsonConst = "Json Const";
         public const string Keyword = "Keyword";
         public const string LanguagePrefix = "&";
         public const string PlainText = "Plain Text";

--- a/ColorCode.Core/Compilation/Languages/JavaScript.cs
+++ b/ColorCode.Core/Compilation/Languages/JavaScript.cs
@@ -78,9 +78,6 @@ namespace ColorCode.Compilation.Languages
             {
                 case "js":
                     return true;
-                
-                case "json":
-                    return true;
 
                 default:
                     return false;

--- a/ColorCode.Core/Compilation/Languages/Json.cs
+++ b/ColorCode.Core/Compilation/Languages/Json.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using ColorCode.Common;
+
+namespace ColorCode.Compilation.Languages
+{
+    /// <summary>
+    /// Leverage the regex from https://gist.github.com/goodmami/02f344e8c9a22fc9ac879230a9b9e071#version-2
+    /// for parsing the key, string value, number, and constant for a JSON code block.
+    /// </summary>
+    public class Json : ILanguage
+    {
+        private const string Regex_String = @"""[^""\\]*(?:\\[^\r\n]|[^""\\]*)*""";
+        private const string Regex_Number = @"-?(?:0|[1-9][0-9]*)(?:\.[0-9]*)?(?:[eE][-+]?[0-9]+)?";
+
+        public string Id
+        {
+            get { return LanguageId.Json; }
+        }
+
+        public string Name
+        {
+            get { return "JSON"; }
+        }
+
+        public string CssClassName
+        {
+            get { return "json"; }
+        }
+
+        public string FirstLinePattern
+        {
+            get { return null; }
+        }
+
+        public IList<LanguageRule> Rules
+        {
+            get
+            {
+                return new List<LanguageRule>
+                           {
+                               new LanguageRule(
+                                   $@"[,\{{]\s*({Regex_String})\s*:",
+                                   new Dictionary<int, string>
+                                       {
+                                           {1, ScopeName.JsonKey}
+                                       }),
+                               new LanguageRule(
+                                   Regex_String,
+                                   new Dictionary<int, string>
+                                       {
+                                           {0, ScopeName.JsonString}
+                                       }),
+                               new LanguageRule(
+                                   Regex_Number,
+                                   new Dictionary<int, string>
+                                       {
+                                           {0, ScopeName.JsonNumber}
+                                       }),
+                               new LanguageRule(
+                                   @"\b(true|false|null)\b",
+                                   new Dictionary<int, string>
+                                       {
+                                           {1, ScopeName.JsonConst}
+                                       }),
+                           };
+            }
+        }
+
+        public bool HasAlias(string lang)
+        {
+            return false;
+        }
+    }
+}

--- a/ColorCode.Core/Languages.cs
+++ b/ColorCode.Core/Languages.cs
@@ -42,6 +42,7 @@ namespace ColorCode
             Load<Css>();
             Load<Cpp>();
             Load<Java>();
+            Load<Json>();
             Load<PowerShell>();
             Load<Typescript>();
             Load<FSharp>();

--- a/ColorCode.Core/Styling/StyleDictionary.DefaultDark.cs
+++ b/ColorCode.Core/Styling/StyleDictionary.DefaultDark.cs
@@ -117,6 +117,26 @@ namespace ColorCode.Styling
                         Foreground = Red,
                         ReferenceName = "htmlEntity"
                     },
+                    new Style(ScopeName.JsonKey)
+                    {
+                        Foreground = DarkOrange,
+                        ReferenceName = "jsonKey"
+                    },
+                    new Style(ScopeName.JsonString)
+                    {
+                        Foreground = DarkCyan,
+                        ReferenceName = "jsonString"
+                    },
+                    new Style(ScopeName.JsonNumber)
+                    {
+                        Foreground = BrightGreen,
+                        ReferenceName = "jsonNumber"
+                    },
+                    new Style(ScopeName.JsonConst)
+                    {
+                        Foreground = BrightPurple,
+                        ReferenceName = "jsonConst"
+                    },
                     new Style(ScopeName.XmlAttribute)
                     {
                         Foreground = VSDarkXMLAttribute,

--- a/ColorCode.Core/Styling/StyleDictionary.DefaultLight.cs
+++ b/ColorCode.Core/Styling/StyleDictionary.DefaultLight.cs
@@ -101,6 +101,26 @@ namespace ColorCode.Styling
                         Foreground = Red,
                         ReferenceName = "htmlEntity"
                     },
+                    new Style(ScopeName.JsonKey)
+                    {
+                        Foreground = DarkOrange,
+                        ReferenceName = "jsonKey"
+                    },
+                    new Style(ScopeName.JsonString)
+                    {
+                        Foreground = DarkCyan,
+                        ReferenceName = "jsonString"
+                    },
+                    new Style(ScopeName.JsonNumber)
+                    {
+                        Foreground = BrightGreen,
+                        ReferenceName = "jsonNumber"
+                    },
+                    new Style(ScopeName.JsonConst)
+                    {
+                        Foreground = BrightPurple,
+                        ReferenceName = "jsonConst"
+                    },
                     new Style(ScopeName.XmlAttribute)
                     {
                         Foreground = Red,

--- a/ColorCode.Core/Styling/StyleDictionary.cs
+++ b/ColorCode.Core/Styling/StyleDictionary.cs
@@ -39,5 +39,8 @@ namespace ColorCode.Styling
         public const string OliveDrab = "#FF6B8E23";
         public const string DarkOliveGreen = "#FF556B2F";
         public const string DarkCyan = "#FF008B8B";
+        public const string DarkOrange = "#FFFF8700";
+        public const string BrightGreen = "#FF00d700";
+        public const string BrightPurple = "#FFaf87ff";
     }
 }


### PR DESCRIPTION
- Add a regex parser for JSON, to generate tokens for keys, strings, numbers, and constants of a Json code block.
- Removed the `json` alias from the JavaScript language parser.

**Before this change**

Keys and value strings are NOT differentiated, and number is not highlighted:

![image](https://github.com/CommunityToolkit/ColorCode-Universal/assets/127450/b365a17b-36a6-4ffc-a280-db1b297e5984)

**After the change**

Keys and value strings are differentiated, and number is highlighted:

Dark theme screenshot:

![image](https://github.com/CommunityToolkit/ColorCode-Universal/assets/127450/28d9bc87-3edd-4c98-b7a2-a044ee5e1ef3)

Light theme screenshot:

![image](https://github.com/CommunityToolkit/ColorCode-Universal/assets/127450/7f3df3f7-8e2a-4c91-bb5f-8564e1a5276b)
