### PR TITLE
Change Json regex to prevent timeout with partial json

### DIFF
--- a/ColorCode.Core/Compilation/Languages/Json.cs
+++ b/ColorCode.Core/Compilation/Languages/Json.cs
@@ -13,7 +13,7 @@ namespace ColorCode.Compilation.Languages
     /// </summary>
     public class Json : ILanguage
     {
-        private const string Regex_String = @"""[^""\\]*(?:\\[^\r\n]|[^""\\]*)*""";
+        private const string Regex_String = @"""[^""\\]*(?:\\[^\r\n]|[^""\\\w]*)*""";
         private const string Regex_Number = @"-?(?:0|[1-9][0-9]*)(?:\.[0-9]*)?(?:[eE][-+]?[0-9]+)?";
 
         public string Id


### PR DESCRIPTION
Json parsing can fail with incomplete json, timing out with no exception thrown. Adding the word boundary match to the regex prevents this. Unsure of any further implications but complete json is still parsed and coloured successfully after the change

Example failing code before change using ColorCode via Markdig


```
using Markdown.ColorCode;
using ColorCode.Styling;
using System;

public class Program
{
	public static void Main()
	{
		
		var markdownPipeline = new Markdig.MarkdownPipelineBuilder()            
			.UseColorCode(styleDictionary: StyleDictionary.DefaultDark)			
			.Build();
		
		var result = Markdig.Markdown.ToHtml("```json\n[\n    {\n        \"jsonfield1\": \"value1\",\n        \"jsonfield2\": \"value2\"\n    },\n    {\n        \"jsonfield1\": \"value1 value1 value1 value1 value1 value1 value1 ",markdownPipeline);
		
		Console.WriteLine(result); 
	}
}

```